### PR TITLE
Deployment script

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,30 @@
+# -*- coding: utf-8 -*-
+import os
+
+from fabric.api import local, run, cd, prefix, env, sudo
+
+if 'PYCON_HOST' not in os.environ:
+    raise Exception('PYCON_HOST should be exported')
+if 'PYCON_PORT' not in os.environ:
+    raise Exception('PYCON_PORT should be exported')
+if 'PYCON_USER' not in os.environ:
+    raise Exception('PYCON_USER should be exported')
+
+env.host_string = '{user}@{host}:{port}'.format(
+                                            user=os.environ['PYCON_USER'],
+                                            host=os.environ['PYCON_HOST'],
+                                            port=os.environ['PYCON_PORT']
+                                            )
+
+def deploy(target='dev', sha1=None):
+    if sha1 is None:
+        # get current working git sha1
+        sha1 = local('git rev-parse HEAD', capture=True)
+    # server code reset to current working sha1
+    home_dir = '/home/pyconkr/{target}.pycon.kr/pyconkr-2016'.format(target=target)
+    with cd(home_dir):
+        sudo('git fetch -p', user='pyconkr')
+        sudo('git reset ' + sha1, user='pyconkr')
+    # worker reload
+    with cd(home_dir):
+        sudo('restart.sh', user='pyconkr')

--- a/fabfile.py
+++ b/fabfile.py
@@ -24,7 +24,7 @@ def deploy(target='dev', sha1=None):
     home_dir = '/home/pyconkr/{target}.pycon.kr/pyconkr-2016'.format(target=target)
     with cd(home_dir):
         sudo('git fetch -p', user='pyconkr')
-        sudo('git reset ' + sha1, user='pyconkr')
+        sudo('git reset --hard ' + sha1, user='pyconkr')
     # worker reload
     with cd(home_dir):
-        sudo('restart.sh', user='pyconkr')
+        sudo('./restart.sh', user='pyconkr')


### PR DESCRIPTION
환경변수에 아래 세 값을 설정해야합니다.
`PYCON_HOST`: 배포할 호스트
`PYCON_PORT`: SSH 포트
`PYCON_USER`: SSH 유저명

fabric이 설치되어있는것을 전제로 하고 있습니다.
fabric 설치 `apt-get install fabric`

기본값은 dev.pycon.kr에 현재 워킹카피의 커밋을 배포 하도록 되어있습니다.
ex) `fab deploy` -> dev.pycon.kr 에 현재 sha1을 배포

www에 배포시 매개변수를 주어야 합니다.
ex) `fab deploy:target=www` -> www.pycon.kr에 현재 sha1을 배포

특정 커밋을 배포할때에는 매개변수를 주어야합니다.
ex) `fab deploy:target=dev,sha1=2389fdasf` -> dev.pycon.kr에 2389fdasf 커밋을 배포
